### PR TITLE
update deprecated rule to trailing_comma_in_multiline

### DIFF
--- a/src/RuleSet/Sets/ModixSet.php
+++ b/src/RuleSet/Sets/ModixSet.php
@@ -138,7 +138,7 @@ final class ModixSet extends AbstractRuleSetDescription
             'standardize_increment' => true,
             'standardize_not_equals' => true,
             'switch_continue_to_break' => true,
-            'trailing_comma_in_multiline_array' => true,
+            'trailing_comma_in_multiline' => true,
             'trim_array_spaces' => true,
             'unary_operator_spaces' => true,
             'visibility_required' => true,


### PR DESCRIPTION
because of 
```
Detected deprecations in use:
- Rule "trailing_comma_in_multiline_array" is deprecated. Use "trailing_comma_in_multiline" instead.
```